### PR TITLE
Allows formatting before ':' in user snippets.

### DIFF
--- a/src/org/golde/discordbot/supportserver/event/StopChattingInTheWrongChannelsPls.java
+++ b/src/org/golde/discordbot/supportserver/event/StopChattingInTheWrongChannelsPls.java
@@ -16,7 +16,7 @@ public class StopChattingInTheWrongChannelsPls extends AbstractMessageChecker {
 		String text = msg.getContentRaw();
 		if(msg.getChannel().getIdLong() == Channels.USER_MADE_SNIPPETS) {
 
-			if(!text.toLowerCase().contains("name:") || !text.toLowerCase().contains("description:")) {
+			if(!text.toLowerCase().contains("name(.*:|:)") || !text.toLowerCase().contains("description(.*:|:)")) {
 				return true;
 			}
 


### PR DESCRIPTION
The regex pattern `trigger(.*:|:)` allows for formatting after the trigger.

E.g - `name(.*:|:)`:
![image](https://user-images.githubusercontent.com/35181375/82110508-4ce77000-9782-11ea-914b-b7a0a6c6ef7e.png)
