### PR TITLE
Make ",ce ByteBuffer" easier to understand.

### DIFF
--- a/Utilities/res/common-errors.json
+++ b/Utilities/res/common-errors.json
@@ -105,7 +105,7 @@
 	{
 		"shortCodes": [ "flip()", "ByteBuffer", "bytebuff", "flip" ],
 		"cmdDesc": "java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;",
-		"detailedDesc": "This is a strange issue but it seems to be fixed by: casting ByteBuffer instances to Buffer before calling the method. I would also double check in your IDE your compiling with Java 8. Just because you have Java 8 Installed does not mean your IDE is compiling with it. For more detail (if your interested): https://github.com/apache/felix/pull/114 and https://www.google.com/search?q=java.lang.NoSuchMethodError:%20java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;",
+		"detailedDesc": "This is a strange issue but it seems to be fixed by: casting ByteBuffer instances to Buffer before calling the method. Open Minecraft.java and find the readImageToBuffer method. Find the line that says `ByteBuffer bytebuffer = ByteBuffer.allocate(4 * aint.length);`.  Before the ByteBuffer.allocate part, put `(ByteBuffer)`. For more detail (if your interested): https://github.com/apache/felix/pull/114 and https://www.google.com/search?q=java.lang.NoSuchMethodError:%20java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;",
 		"crashReport": [ "java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;" ]
 	},
 	{


### PR DESCRIPTION
made the command a lot easier. go to the readImageToBuffer method, find the line with `ByteBuffer bytebuffer = ByteBuffer.allocate(4* aint.length);` and cast it to a ByteBuffer.